### PR TITLE
Feature/initial Rx command option

### DIFF
--- a/gsm/gsm.go
+++ b/gsm/gsm.go
@@ -67,10 +67,10 @@ func (o initialCmdOption) applyRxOption(c *rxConfig) {
 	c.initialCmd = string(o)
 }
 
-// WithInitialCommand overrides the initial command
+// WithInitialCmd overrides the initial command
 //
 // The default is "+CNMI=1,2,0,0,0"
-func WithInitialCommand(cmd string) RxOption {
+func WithInitialCmd(cmd string) RxOption {
 	return initialCmdOption(cmd)
 }
 


### PR DESCRIPTION
`+CNMI=1,2,0,0,0` not working with my device, it said:
```
2020/06/08 06:35:16 /dev/ttyACM0, w: AT+CNMI=1,2,0,0,0
2020/06/08 06:35:16 /dev/ttyACM0, r:
+CMS ERROR: unknown error
```
I must to change command to `+CNMI=1,2,0,0,1` to get it working. My device also require to initial with `+CSMS=1` before send `<mt>=2,3`.

>  Parameters <mt>=2,3 and <ds>=1 are only available with GSM phase 2+ (see AT+CSMS=1). Incoming SMs or Status Reports have to be acknowledged with AT+CNMA=0 when using these phase 2+ parameters. 

It can fixed, with `at.WithCmds("Z", "E0", "+CSMS=1")`