### PR TITLE
Fix Wavecom modem error

### DIFF
--- a/gsm/gsm.go
+++ b/gsm/gsm.go
@@ -162,7 +162,7 @@ func (g *GSM) Init(options ...at.InitOption) (err error) {
 	}
 	cmds := []string{
 		"+CMGF=1", // text mode
-		"+CMEE=2", // textual errors
+		"+CMEE=1", // textual errors
 	}
 	if g.pduMode {
 		cmds[0] = "+CMGF=0" // pdu mode


### PR DESCRIPTION
In function gsm.Init,    the command "+CMEE=2", return "Error"  when   using    Wavecom modem